### PR TITLE
New plugins

### DIFF
--- a/agent/kill/kill.ddl
+++ b/agent/kill/kill.ddl
@@ -1,0 +1,20 @@
+metadata    :name        => "SimpleRPC Ubuntu Kill Agent",
+            :description => "Agent to kill instances",
+            :author      => "Marc Cluet",
+            :license     => "Apache License 2.0",
+            :version     => "1.3",
+            :url         => "https://launchpad.net/~canonical-sig/",
+            :timeout     => 30
+
+action "kill", :description => "Kills instance nicely" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "forcekill", :description => "Kills instance the nasty way" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+

--- a/agent/kill/kill.rb
+++ b/agent/kill/kill.rb
@@ -1,0 +1,44 @@
+module MCollective
+    module Agent
+        # An agent to kill instances
+        #
+        # Configuration Options:
+        #    kill.halt - Location of halt binary
+        #
+        class Kill<RPC::Agent
+            metadata    :name        => "SimpleRPC Puppet Ubuntu Agent",
+                        :description => "Agent to manage puppet the Ubuntu way",
+                        :author      => "Marc Cluet",
+                        :license     => "Apache License 2.0",
+                        :version     => "1.3",
+                        :url         => "https://launchpad.net/~canonical-sig/",
+                        :timeout     => 30
+
+            def startup_hook
+                @halt = config.pluginconf["kill.halt"] || "/sbin/halt"
+            end
+
+            # Kills instance
+            action "kill" do
+                logger.debug ("Killing instance")
+                reply[:exitcode] = run("#{@halt}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error killing instance"
+                end
+            end
+
+            # Kills instance with prejudice
+            action "forcekill" do
+                logger.debug ("Killing instance through sysrq")
+                reply[:exitcode] = run("echo '1' > /proc/sys/kernel/sysrq ; echo 'o' > /proc/sysrq-trigger", :stdout => :output, :stderr => :err, :chomp => true)
+                reply[:exitcode] = 0
+
+                # Never expect an answer from this, it's nasty
+            end
+
+        end
+    end
+end
+
+# vi:tabstop=4:expandtab:ai:filetype=ruby

--- a/agent/kill/mc-kill
+++ b/agent/kill/mc-kill
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# Client program for the mcollective instance kill agent
+# Copyright 2011 Canonical Ltd.
+# Released under Apache License
+
+require 'mcollective'
+
+include MCollective::RPC
+
+options = rpcoptions do |parser, options|
+    parser.define_head "Manage puppet on Ubuntu"
+    parser.banner = "Usage: mc-kill [-options] [kill|forcekill]"
+
+    parser.separator ""
+    parser.separator "Run Options"
+end
+
+killrpc = rpcclient("kill", {:options => options})
+
+def log(msg)
+    puts("#{Time.now} - #{msg}")
+end
+
+def summarize(stats)
+    puts("\n---- kill agent summary ----")
+    puts("           Nodes: #{stats[:discovered]} / #{stats[:responses]}")
+    printf("    Elapsed Time: %.2f s\n\n", stats[:blocktime])
+end
+
+if  ARGV.length == 1
+    action = ARGV.shift
+
+    unless action =~ /^(kill|forcekill)$/
+        puts("Action has to be kill or forcekill")
+        exit 1
+    end
+    killrpc.send(action).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+else
+    puts("Usage: mc-kill [-options] [kill|forcekill]")
+    exit 1
+end
+
+summarize(killrpc.stats)
+
+killrpc.disconnect
+# vi:tabstop=4:expandtab:ai

--- a/agent/uapt/mc-uapt
+++ b/agent/uapt/mc-uapt
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# Client program for the mcollective uapt agent
+# Copyright 2011 Canonical Ltd.
+# Released under Apache License
+
+require 'mcollective'
+
+include MCollective::RPC
+
+options = rpcoptions do |parser, options|
+    parser.define_head "Manage apt on Ubuntu"
+    parser.banner = "Usage: mc-uapt [-options] [update|upgrade|dist-upgrade|install|forceinstall|remove|source|clean] {package}"
+
+    parser.separator ""
+    parser.separator "Run Options"
+end
+
+uaptrpc = rpcclient("uapt", {:options => options})
+
+def log(msg)
+    puts("#{Time.now} - #{msg}")
+end
+
+def summarize(stats)
+    puts("\n---- uapt agent summary ----")
+    puts("           Nodes: #{stats[:discovered]} / #{stats[:responses]}")
+    printf("    Elapsed Time: %.2f s\n\n", stats[:blocktime])
+end
+
+if  ARGV.length == 2
+    action = ARGV.shift
+    package = ARGV.shift
+
+    unless action =~ /^(install|remove|source)$/
+        puts("Action has to be install, remove or source")
+        exit 1
+    end
+    uaptrpc.send(action, {:package => package}).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+elsif  ARGV.length == 1
+    action = ARGV.shift
+
+    unless action =~ /^(update|upgrade|dist-upgrade|forceinstall|clean)$/
+        puts("Action has to be update, upgrade, dist-upgrade, forceinstall or clean")
+        exit 1
+    end
+    uaptrpc.send(action).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+else
+    puts("Usage: mc-uapt [-options] [update|upgrade|dist-upgrade|install|forceinstall|remove|source|clean] {package}")
+    exit 1
+end
+
+summarize(uaptrpc.stats)
+
+uaptrpc.disconnect
+# vi:tabstop=4:expandtab:ai

--- a/agent/uapt/uapt.ddl
+++ b/agent/uapt/uapt.ddl
@@ -1,0 +1,80 @@
+metadata    :name        => "SimpleRPC Ubuntu APT Agent",
+            :description => "Agent to manage apt the Ubuntu way",
+            :author      => "Marc Cluet",
+            :license     => "Apache License 2.0",
+            :version     => "1.3",
+            :url         => "https://launchpad.net/~canonical-sig/",
+            :timeout     => 360
+
+action "update", :description => "Update APT" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "upgrade", :description => "Upgrade APT" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "dist-upgrade", :description => "Dist-Upgrade APT" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "install", :description => "Installs package through APT" do
+    input  :package, 
+           :prompt      => "package name",
+           :description => "Package Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "forceinstall", :description => "Force installs package through APT" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "remove", :description => "Removes package through APT" do
+    input  :package, 
+           :prompt      => "package name",
+           :description => "Package Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "source", :description => "Installs source package through APT" do
+    input  :package, 
+           :prompt      => "package name",
+           :description => "Package Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "clean", :description => "Clean downloaded packages through APT" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+

--- a/agent/uapt/uapt.rb
+++ b/agent/uapt/uapt.rb
@@ -1,0 +1,105 @@
+module MCollective
+    module Agent
+        # An agent to manage apt 
+        #
+        # Configuration Options:
+        #    uapt.apt_get - Location of apt-get
+        #
+        class Uapt<RPC::Agent
+            metadata    :name        => "SimpleRPC APT Ubuntu Agent",
+                        :description => "Agent to manage apt the Ubuntu way",
+                        :author      => "Marc Cluet",
+                        :license     => "Apache License 2.0",
+                        :version     => "1.3",
+                        :url         => "https://launchpad.net/~canonical-sig/",
+                        :timeout     => 360
+
+            def startup_hook
+                @apt_get = config.pluginconf["uapt.apt_get"] || "/usr/bin/apt-get"
+            end
+
+            # apt-get update
+            action "update" do
+                logger.debug ("Running apt-get update")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y update", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error updating apt repositories"
+                end
+            end
+
+            # apt-get upgrade
+            action "upgrade" do
+                logger.debug ("Running apt-get upgrade")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y upgrade", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error upgrading packages"
+                end
+            end
+
+            # apt-get dist-upgrade
+            action "dist-upgrade" do
+                logger.debug ("Running apt-get dist-upgrade")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y dist-upgrade", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running dist-upgrade"
+                end
+            end
+
+            # apt-get install
+            action "install" do
+                logger.debug ("Running apt-get install #{request[:package]}")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y install #{request[:package]}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running apt-get install #{request[:package]}"
+                end
+            end
+
+            # apt-get -f install
+            action "forceinstall" do
+                logger.debug ("Running apt-get -f install")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -f install", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running apt-get -f install"
+                end
+            end
+
+            # apt-get remove
+            action "remove" do
+                logger.debug ("Running apt-get remove #{request[:package]}")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y remove #{request[:package]}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running apt-get remove #{request[:package]}"
+                end
+            end
+
+            # apt-get source
+            action "source" do
+                logger.debug ("Running apt-get source #{request[:package]}")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} -y source #{request[:package]}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running apt-get source #{request[:package]}"
+                end
+            end
+
+            # apt-get clean
+            action "clean" do
+                logger.debug ("Running apt-get clean")
+                reply[:exitcode] = run("export DEBIAN_FRONTEND=noninteractive; #{@apt_get} clean", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error running apt-get clean"
+                end
+            end
+
+        end
+    end
+end
+
+# vi:tabstop=4:expandtab:ai:filetype=ruby

--- a/agent/upuppet/mc-upuppet
+++ b/agent/upuppet/mc-upuppet
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# Client program for the mcollective upuppet agent
+# Copyright 2011 Canonical Ltd.
+# Released under Apache License
+
+require 'mcollective'
+
+include MCollective::RPC
+
+options = rpcoptions do |parser, options|
+    parser.define_head "Manage puppet on Ubuntu"
+    parser.banner = "Usage: mc-upuppet [-options] [start|stop|restart|cycle_run] {numtimes}"
+
+    parser.separator ""
+    parser.separator "Run Options"
+end
+
+upuppetrpc = rpcclient("upuppet", {:options => options})
+
+def log(msg)
+    puts("#{Time.now} - #{msg}")
+end
+
+def summarize(stats)
+    puts("\n---- upuppet agent summary ----")
+    puts("           Nodes: #{stats[:discovered]} / #{stats[:responses]}")
+    printf("    Elapsed Time: %.2f s\n\n", stats[:blocktime])
+end
+
+if  ARGV.length == 2
+    action = ARGV.shift
+    numtimes = ARGV.shift
+
+    unless action =~ /^(cycle_run)$/
+        puts("Action has to be cycle_run")
+        exit 1
+    end
+    upuppetrpc.send(action, {:numtimes => numtimes}).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+elsif  ARGV.length == 1
+    action = ARGV.shift
+
+    unless action =~ /^(start|stop|restart)$/
+        puts("Action has to be start,stop or restart")
+        exit 1
+    end
+    upuppetrpc.send(action).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+else
+    puts("Usage: mc-upuppet [-options] [start|stop|restart|cycle_run] {numtimes}")
+    exit 1
+end
+
+summarize(upuppetrpc.stats)
+
+upuppetrpc.disconnect
+# vi:tabstop=4:expandtab:ai

--- a/agent/upuppet/upuppet.ddl
+++ b/agent/upuppet/upuppet.ddl
@@ -1,0 +1,40 @@
+metadata    :name        => "SimpleRPC Ubuntu Puppet Agent",
+            :description => "Agent to manage puppet the Ubuntu way",
+            :author      => "Marc Cluet",
+            :license     => "Apache License 2.0",
+            :version     => "1.3",
+            :url         => "https://launchpad.net/~canonical-sig/",
+            :timeout     => 1000
+
+action "stop", :description => "Stops Puppet Service" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "start", :description => "Starts Puppet Service" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "restart", :description => "Restarts Puppet Service" do
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+action "cycle_run", :description => "Runs puppet service in cycle" do
+    input  :numtimes, 
+           :prompt      => "numtimes",
+           :description => "Number of Times",
+           :type        => :integer,
+           :optional    => true,
+           :maxlength   => 2
+
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+
+

--- a/agent/upuppet/upuppet.rb
+++ b/agent/upuppet/upuppet.rb
@@ -1,0 +1,75 @@
+module MCollective
+    module Agent
+        # An agent to manage puppet the Ubuntu way
+        #
+        # Configuration Options:
+        #    upuppet.puppetd - Location of puppet binary
+        #
+        class Upuppet<RPC::Agent
+            metadata    :name        => "SimpleRPC Puppet Ubuntu Agent",
+                        :description => "Agent to manage puppet the Ubuntu way",
+                        :author      => "Marc Cluet",
+                        :license     => "Apache License 2.0",
+                        :version     => "1.3",
+                        :url         => "https://launchpad.net/~canonical-sig/",
+                        :timeout     => 1000
+
+            def startup_hook
+                @puppetd = config.pluginconf["upuppet.puppetd"] || "/usr/sbin/puppetd"
+            end
+
+            # Starts puppet
+            action "start" do
+                logger.debug ("Starting Puppet Service")
+                reply[:exitcode] = run("service puppet start", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error starting Puppet."
+                end
+            end
+
+            # Stops puppet
+            action "stop" do
+                logger.debug ("Stopping Puppet Service")
+                reply[:exitcode] = run("service puppet stop", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error stopping Puppet"
+                end
+            end
+
+            # Restart puppet
+            action "restart" do
+                logger.debug ("Restarting Puppet Service")
+                reply[:exitcode] = run("service puppet restart", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error restarting Puppet"
+                end
+            end
+
+            # Reads a fact
+            action "cycle_run" do
+                if request[:numtimes].nil?
+                    numtimes = 3
+                else
+                    numtimes = Integer(request[:numtimes])
+                end
+                logger.debug ("Cycle running puppet #{numtimes} times")
+                counter = 1
+                null = %x[service puppet stop]
+                while counter <= numtimes
+                    logger.debug ("Cycle running puppet: #{counter} LOOP")
+                    reply[:exitcode] = run("#{@puppetd} --test --color=none --summarize", :stdout => :stdout, :stderr => :err, :chomp => true)
+                    counter+=1
+                end
+                null = %x[service puppet start]
+                reply[:output] = "OK"
+                reply[:exitcode] = 0
+            end
+
+        end
+    end
+end
+
+# vi:tabstop=4:expandtab:ai:filetype=ruby

--- a/agent/uservice/mc-uservice
+++ b/agent/uservice/mc-uservice
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# Client program for the mcollective service agent
+# Copyright 2011 Canonical Ltd.
+# Released under Apache License
+
+require 'mcollective'
+
+include MCollective::RPC
+
+options = rpcoptions do |parser, options|
+    parser.define_head "Manage Ubuntu services"
+    parser.banner = "Usage: mc-uservice [-options] [start|stop|restart|status] [service_name]"
+
+    parser.separator ""
+    parser.separator "Run Options"
+end
+
+servicerpc = rpcclient("uservice", {:options => options})
+
+def log(msg)
+    puts("#{Time.now} - #{msg}")
+end
+
+def summarize(stats)
+    puts("\n---- service agent summary ----")
+    puts("           Nodes: #{stats[:discovered]} / #{stats[:responses]}")
+    printf("    Elapsed Time: %.2f s\n\n", stats[:blocktime])
+end
+
+if  ARGV.length == 2
+    action = ARGV.shift
+    servicename = ARGV.shift
+
+    unless action =~ /^(start|stop|restart|status)$/
+        puts("Action has to be start, stop, restart or status")
+        exit 1
+    end
+    servicerpc.send(action, {:service => servicename}).each do |node|
+        begin
+            if node[:data][:output].nil?
+                printf("%-40s %s\n", node[:sender], node[:statusmsg])
+            else
+                printf("%-40s %s\n", node[:sender], node[:data][:output])
+            end
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+else
+    puts("Usage: mc-uservice [-options] [start|stop|restart|status] [service]")
+    exit 1
+end
+
+summarize(servicerpc.stats)
+
+servicerpc.disconnect
+# vi:tabstop=4:expandtab:ai

--- a/agent/uservice/uservice.ddl
+++ b/agent/uservice/uservice.ddl
@@ -1,0 +1,51 @@
+metadata    :name        => "SimpleRPC Ubuntu Service Agent",
+            :description => "Agent to manage services in Ubuntu",
+            :author      => "Marc Cluet",
+            :license     => "Apache License 2.0",
+            :version     => "1.3",
+            :url         => "https://launchpad.net/~canonical-sig/",
+            :timeout     => 30
+
+action "stop", :description => "Stops Service" do
+    input  :service, 
+           :prompt      => "service name",
+           :description => "Service Name",
+           :type        => :string,
+           :optional    => false,
+           :maxlength   => 50
+end
+
+action "start", :description => "Starts Service" do
+    input  :service, 
+           :prompt      => "service name",
+           :description => "Service Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 50
+end
+
+action "restart", :description => "Restarts Service" do
+    input  :service, 
+           :prompt      => "service name",
+           :description => "Service Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 50
+end
+
+action "status", :description => "Gets Service Status" do
+    input  :service, 
+           :prompt      => "service name",
+           :description => "Service Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 50
+
+    output :output,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+

--- a/agent/uservice/uservice.rb
+++ b/agent/uservice/uservice.rb
@@ -1,0 +1,73 @@
+module MCollective
+    module Agent
+        # An agent to manage Ubuntu services
+        #
+        # Configuration Options:
+        #    service.service - Location of service bin
+        #
+        class Uservice<RPC::Agent
+            metadata    :name        => "SimpleRPC Ubuntu Service Agent",
+                        :description => "Agent to manage Ubuntu services",
+                        :author      => "Marc Cluet",
+                        :license     => "Apache License 2.0",
+                        :version     => "1.3",
+                        :url         => "https://launchpad.net/~canonical-sig/",
+                        :timeout     => 30
+
+            def startup_hook
+                @service = config.pluginconf["service.service"] || "/usr/sbin/service"
+            end
+
+            # Starts Service
+            action "start" do
+                if request[:service].nil?
+                    fail "Service name not provided"
+                end
+                logger.debug ("Starting Service #{request[:service]}")
+                reply[:exitcode] = run("#{@service} #{request[:service]} start", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error starting service #{request[:service]}."
+                end
+            end
+
+            # Stops Service
+            action "stop" do
+                if request[:service].nil?
+                    fail "Service name not provided"
+                end
+                logger.debug ("Stopping Service #{request[:service]}")
+                reply[:exitcode] = run("#{@service} #{request[:service]} stop", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error stopping service #{request[:service]}."
+                end
+            end
+
+            # Restarts Service
+            action "restart" do
+                if request[:service].nil?
+                    fail "Service name not provided"
+                end
+                logger.debug ("Restarting Service #{request[:service]}")
+                reply[:exitcode] = run("#{@service} #{request[:service]} restart", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Error restarting service #{request[:service]}."
+                end
+            end
+
+            # Gives back status
+            action "status" do
+                if request[:service].nil?
+                    fail "Service name not provided"
+                end
+                logger.debug ("Getting Service status #{request[:service]}")
+                reply[:exitcode] = run("#{@service} #{request[:service]} status", :stdout => :output, :stderr => :err, :chomp => true)
+            end
+
+        end
+    end
+end
+
+# vi:tabstop=4:expandtab:ai:filetype=ruby

--- a/facts/fact/fact.ddl
+++ b/facts/fact/fact.ddl
@@ -1,0 +1,49 @@
+metadata    :name        => "SimpleRPC Fact Agent",
+            :description => "Agent to manage facts",
+            :author      => "Marc Cluet",
+            :license     => "Apache License 2.0",
+            :version     => "1.3",
+            :url         => "https://launchpad.net/~canonical-sig/",
+            :timeout     => 20
+
+action "add", :description => "Adds fact" do
+    input  :fact, 
+           :prompt      => "fact",
+           :description => "Fact Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+
+    input  :value, 
+           :prompt      => "value",
+           :description => "Value",
+           :type        => :string,
+           :optional    => false,
+           :maxlength   => 90
+end
+
+action "del", :description => "Deletes fact" do
+    input  :fact, 
+           :prompt      => "fact",
+           :description => "Fact Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+end
+
+action "read", :description => "Reads fact" do
+    input  :fact, 
+           :prompt      => "fact",
+           :description => "Fact Name",
+           :type        => :string,
+           :validation  => '.',
+           :optional    => false,
+           :maxlength   => 90
+
+    output :result,
+           :description => "Output fact",
+           :display_as => "Output"
+end
+

--- a/facts/fact/fact.rb
+++ b/facts/fact/fact.rb
@@ -1,0 +1,55 @@
+module MCollective
+    module Agent
+        # An agent to manage Facts
+        #
+        # Configuration Options:
+        #    fact.fact_add - Add a new fact
+        #    fact.fact_del - Deletes an existing fact
+        #
+        class Fact<RPC::Agent
+            metadata    :name        => "SimpleRPC Fact Agent",
+                        :description => "Agent to manage Facts",
+                        :author      => "Marc Cluet",
+                        :license     => "Apache License 2.0",
+                        :version     => "1.3",
+                        :url         => "https://launchpad.net/~canonical-sig/",
+                        :timeout     => 20
+
+            def startup_hook
+                @fact_add = config.pluginconf["fact.fact_add"] || "/usr/bin/fact-add"
+                @fact_del = config.pluginconf["fact.fact_del"] || "/usr/bin/fact-del"
+                @facter = config.pluginconf["fact.facter"] || "/usr/bin/facter"
+            end
+
+            # Adds a new fact
+            action "add" do
+                logger.debug ("Request for adding fact #{request[:fact]} with value #{request[:value]}")
+                reply[:exitcode] = run("#{@fact_add} #{request[:fact]} #{request[:value]}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Unable to add fact"
+                end
+            end
+
+            # Deletes an existing fact
+            action "del" do
+                logger.debug ("Request for deleting fact #{request[:fact]}")
+                reply[:exitcode] = run("#{@fact_add} #{request[:fact]} #{request[:value]}", :stdout => :output, :stderr => :err, :chomp => true)
+
+                if reply[:exitcode] != 0
+                    fail "Can't delete not existing fact"
+                end
+            end
+
+            # Reads a fact
+            action "read" do
+                logger.debug ("Request for reading fact #{request[:fact]}")
+                reply[:output] = PluginManager["facts_plugin"].get_fact("#{request[:fact]}")
+                reply[:exitcode] = 0
+            end
+
+        end
+    end
+end
+
+# vi:tabstop=4:expandtab:ai:filetype=ruby

--- a/facts/fact/mc-fact
+++ b/facts/fact/mc-fact
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# Client program for the mcollective fact agent
+# Copyright 2011 Canonical Ltd.
+# Released under Apache License
+
+require 'mcollective'
+
+include MCollective::RPC
+
+options = rpcoptions do |parser, options|
+    parser.define_head "Manage remote facts"
+    parser.banner = "Usage: mc-fact [-options] [add|del|read] [fact] {value}"
+
+    parser.separator ""
+    parser.separator "Run Options"
+end
+
+factrpc = rpcclient("fact", {:options => options})
+
+def log(msg)
+    puts("#{Time.now} - #{msg}")
+end
+
+def summarize(stats)
+    puts("\n---- fact agent summary ----")
+    puts("           Nodes: #{stats[:discovered]} / #{stats[:responses]}")
+    printf("    Elapsed Time: %.2f s\n\n", stats[:blocktime])
+end
+
+if ARGV.length == 3
+    action = ARGV.shift
+    fact = ARGV.shift
+    value = ARGV.shift
+
+    unless action =~ /^(add|write)$/
+        puts("Action has to be add")
+        exit 1
+    end
+
+    if action == "write"
+        action = "add"
+    end
+
+    factrpc.send(action, {:fact => fact, :value => value}).each do |node|
+        begin
+            printf("%-40s %s\n", node[:sender], node[:statusmsg])
+        rescue StandardError => e
+            log "The RPC agent #{node[:sender]} returned an error: #{e}"
+        end
+    end
+elsif  ARGV.length == 2
+    action = ARGV.shift
+    fact = ARGV.shift
+
+    unless action =~ /^(read|del)$/
+        puts("Action has to be read or del")
+        exit 1
+    end
+
+    if action == "del"
+        factrpc.send(action, {:fact => fact}).each do |node|
+            begin
+                printf("%-40s %s\n", node[:sender], node[:statusmsg])
+            rescue StandardError => e
+                log "The RPC agent #{node[:sender]} returned an error: #{e}"
+            end
+        end
+    end
+    if action == "read"
+        factrpc.send(action, {:fact => fact}).each do |node|
+            begin
+                printf("%-40s %s\n", node[:sender], node[:data][:output])
+            rescue StandardError => e
+                log "The RPC agent #{node[:sender]} returned an error: #{e}"
+            end
+        end
+    end
+else
+    puts("Usage: mc-fact [-options] [add|del|read] [fact] {value}")
+    exit 1
+end
+
+summarize(factrpc.stats)
+
+factrpc.disconnect
+# vi:tabstop=4:expandtab:ai


### PR DESCRIPTION
mc-fact
It reads facts from the fact backbone and adds facts using our own fact backbone

mc-uapt
Manages apt in Ubuntu directly instead of using puppet services to be able to handle extended features available in apt

mc-uservice
Manages services in Ubuntu directly using service to be able to handle extended features

mc-upuppet
Manages puppet in Ubuntu through service and adds extra functionality desired

mc-kill
Kills nodes either by "halt"ing the instance or by doing a sysrq halt
