### PR TITLE
Check for mis-configuration in registration-mongodb

### DIFF
--- a/agent/registration-mongodb/registration.rb
+++ b/agent/registration-mongodb/registration.rb
@@ -55,6 +55,11 @@ module MCollective
             def handlemsg(msg, connection)
                 req = msg[:body]
 
+                if (req.kind_of?(Array))
+                    Log.instance.warn("Got no facts - did you forget to add 'registration = Meta' to your server.cfg?");
+                    return nill
+                end
+
                 req[:fqdn] = req[:facts]["fqdn"]
                 req[:lastseen] = Time.now.to_i
 


### PR DESCRIPTION
This check makes it more obvious if you have failed to configure the meta registration plugin,
which is needed by this plugin. You'll get a warning in the log telling you what to do to your
server.cfg, rather than a cryptic error which only googles to pastebins of the same error
