### PR TITLE
Change name to title

### DIFF
--- a/agent/puppetral/agent/puppetral.ddl
+++ b/agent/puppetral/agent/puppetral.ddl
@@ -41,8 +41,8 @@ action "find", :description => "Get the value of a resource" do
           :optional    => false,
           :maxlength   => 90
 
-    input :name,
-          :prompt      => "Resource name",
+    input :title,
+          :prompt      => "Resource title",
           :description => "Name of resource to check",
           :type        => :string,
           :validation  => '.',
@@ -56,7 +56,7 @@ action "find", :description => "Get the value of a resource" do
     ouput :title,
     	  :description => "Title of the inspected resource",
 	  :display_as  => "Title"
-	  
+
     output :tags,
     	   :description => "Tags of the inspected resource",
 	   :display_as  => "Tags"

--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -41,18 +41,18 @@ module MCollective
 
       action "find" do
         type = request[:type]
-        name = request[:name]
+        title = request[:title]
         typeobj = Puppet::Type.type(type) or raise "Could not find type #{type}"
 
         if typeobj
-          result = Puppet::Resource.indirection.find([type, name].join('/')).to_pson_data_hash
+          result = Puppet::Resource.indirection.find([type, title].join('/')).to_pson_data_hash
 
           result.each { |k,v| reply[k] = v }
 
           begin
             managed_resources = File.readlines(`puppet agent --configprint resourcefile`.chomp)
             managed_resources = managed_resources.map{|r|r.chomp}
-            reply[:managed] = managed_resources.include?("#{type}[#{name}]")
+            reply[:managed] = managed_resources.include?("#{type}[#{title}]")
           rescue
             reply[:managed] = "unknown"
           end
@@ -61,7 +61,6 @@ module MCollective
 
       action "search" do
         type = request[:type]
-        name = request[:name]
         typeobj = Puppet::Type.type(type) or raise "Could not find type #{type}"
 
         if typeobj


### PR DESCRIPTION
The puppetral agent contained some references to the "name" of a resource, when the proper term is "title". This commit changes all occurrences to title.
