### PR TITLE
Match output of `puppet resource`

### DIFF
--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -47,6 +47,8 @@ module MCollective
         if typeobj
           result = Puppet::Resource.indirection.find([type, title].join('/')).to_pson_data_hash
 
+          properties = typeobj.properties.collect { |s| s.name.to_s }
+          result['parameters'].each { |p, v| result['parameters'].delete p if ((p.to_s != 'ensure' && v == :absent) || !(properties.include?(p.to_s))) }
           result.each { |k,v| reply[k] = v }
 
           begin


### PR DESCRIPTION
In order to match the behavior of `puppet resource` this commit removes
all non-property parameters and 'absent' values from puppetral#find
results. The only exception is when ensure is set to absent.

Reviewed-by: Joshua Lifton lifton@puppetlabs.com
