### PR TITLE
Updated puppetral's create_resource method to return the created resource, if any.

### DIFF
--- a/agent/puppetral/agent/puppetral.ddl
+++ b/agent/puppetral/agent/puppetral.ddl
@@ -33,9 +33,14 @@ action "create", :description => "Add a resource to the RAL" do
           :optional    => true,
           :maxlength   => 90
 
-    output :output,
+    output :status,
            :description => "Message indicating success or failure of the action",
-           :display_as  => "Result"
+           :display_as  => "Status"
+
+    output :resource,
+           :description => "Resource that was created",
+           :display_as  => "Resource"
+
 end
 
 action "find", :description => "Get the value of a resource" do

--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -38,11 +38,14 @@ module MCollective
 
         success = true
         if report && report.resource_statuses.first.last.failed
-          reply[:output] = report.resource_statuses.first.last.events.first.message
+          reply[:status] = report.resource_statuses.first.last.events.first.message
           success = false
         end
 
-        reply[:output] = "Resource was created" if success
+        if success
+          reply[:status] = "Resource was created"
+          reply[:resource] = result.to_pson_data_hash
+        end
       end
 
       # Remove the avoid_conflict property if it clashes in one or more of


### PR DESCRIPTION
Previously, the create_resource method returned a human readable
string indicating success or failure of the create operation. The
create_resource method now also returns the actual resource that was
created, if any.
