### PR TITLE
Correct validation for OS X Services

### DIFF
--- a/agent/service/agent/service.ddl
+++ b/agent/service/agent/service.ddl
@@ -13,9 +13,9 @@ action "status", :description => "Gets the status of a service" do
           :prompt      => "Service Name",
           :description => "The service to get the status for",
           :type        => :string,
-          :validation  => '^[a-zA-Z\-_\d]+$',
+          :validation  => '^[a-zA-Z\.\-_\d]+$',
           :optional    => false,
-          :maxlength   => 30
+          :maxlength   => 90
 
     output "status",
           :description => "The status of service",
@@ -30,9 +30,9 @@ end
               :prompt      => "Service Name",
               :description => "The service to #{act}",
               :type        => :string,
-              :validation  => '^[a-zA-Z\-_\d]+$',
+              :validation  => '^[a-zA-Z\.\-_\d]+$',
               :optional    => false,
-              :maxlength   => 30
+              :maxlength   => 90
     
         output "status",
               :description => "The status of service after #{act}",


### PR DESCRIPTION
OS X service names use a format of 'com.openssh.sshd' and can get
quite long.  This commit adds periods (.) into the validation check
and sets the length to be 90 characters.
