### PR TITLE
puppetral#create resource info

### DIFF
--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -43,7 +43,7 @@ module MCollective
 
         if success
           reply[:status] = "Resource was created"
-          reply[:resource] = retain_params(result)
+          reply[:resource] = retain_params(Puppet::Resource.indirection.find([type, title].join('/')))
         end
       end
 


### PR DESCRIPTION
Instead of returning the result of the Puppet::Resource.indirection.save
under the :resource key, we now instead do a find. This has the effect
of returning more information about the created resource, since the
return value of indirection.save only contains info about the parameters
that changed, and not about all properties of the resource.

Reviewed-by: Joshua Lifton lifton@puppetlabs.com
