### PR TITLE
Fix another order dependent failure

### DIFF
--- a/agent/service/agent/puppet-service.rb
+++ b/agent/service/agent/puppet-service.rb
@@ -1,3 +1,5 @@
+require 'puppet'
+
 module MCollective
   module Agent
     # An agent that uses Puppet to manage services
@@ -38,8 +40,6 @@ module MCollective
         if @config.pluginconf.include?("service.hasstatus")
           hasstatus = true if @config.pluginconf["service.hasstatus"] =~ /^1|y|t/
         end
-
-        require 'puppet'
 
         if ::Puppet.version =~ /0.24/
           ::Puppet::Type.type(:service).clear

--- a/agent/service/spec/service_agent_spec.rb
+++ b/agent/service/spec/service_agent_spec.rb
@@ -1,11 +1,6 @@
 #!/usr/bin/env rspec
 require 'spec_helper'
 
-module Puppet
-  class Type
-  end
-end
-
 describe "service agent" do
   before do
     agent_file = File.join([File.dirname(__FILE__), "../agent/puppet-service.rb"])


### PR DESCRIPTION
The service agent was also redeclaring Puppet::Type, so the package and
puppetral agents' specs failed when run after.
