### PR TITLE
(#10578) Improve the text around signalling a daemonized puppet agent.

### DIFF
--- a/agent/puppetd/agent/puppetd.rb
+++ b/agent/puppetd/agent/puppetd.rb
@@ -119,7 +119,7 @@ module MCollective
               # theoretically signal arbitrary processes with this...
               begin
                 ::Process.kill("USR1", Integer(pid))
-                reply[:output] = "Sent SIGUSR1 to the puppet agent daemon (process #{Integer(pid)})"
+                reply[:output] = "Signalled daemonized puppet agent to run (process #{Integer(pid)})"
               rescue Exception => e
                 reply.fail "Failed to signal the puppet agent daemon (process #{pid}): #{e}"
               end

--- a/agent/puppetd/spec/puppetd_agent_spec.rb
+++ b/agent/puppetd/spec/puppetd_agent_spec.rb
@@ -146,7 +146,7 @@ describe "puppetd agent" do
       ::Process.expects(:kill).with("USR1", 99999999).once
       result = @agent.call(:runonce)
       result[:statusmsg].should == "OK"
-      result[:data][:output].should == "Sent SIGUSR1 to the puppet agent daemon (process 99999999)"
+      result[:data][:output].should == "Signalled daemonized puppet agent to run (process 99999999)"
       result.should be_successful
     end
 


### PR DESCRIPTION
Focus on the outcome from the user point of view, not the mechanics
of how the operation is performed.
