### PR TITLE
Edit description strings of agents included in PE2

### DIFF
--- a/agent/package/agent/package.ddl
+++ b/agent/package/agent/package.ddl
@@ -1,5 +1,5 @@
-metadata    :name        => "SimpleRPC Agent For Package Management",
-            :description => "Agent to manage packages",
+metadata    :name        => "package",
+            :description => "Install and uninstall software packages",
             :author      => "R.I.Pienaar",
             :license     => "ASL2",
             :version     => "1.3",

--- a/agent/package/agent/puppet-package.rb
+++ b/agent/package/agent/puppet-package.rb
@@ -10,8 +10,8 @@ module MCollective
     #
     # As this agent is based on Simple RPC, it requires mcollective 0.4.7 or newer.
     class Package<RPC::Agent
-      metadata    :name        => "SimpleRPC Agent For Package Management",
-                  :description => "Agent To Manage Packages",
+      metadata    :name        => "package",
+                  :description => "Install and uninstall software packages",
                   :author      => "R.I.Pienaar",
                   :license     => "ASL2",
                   :version     => "2.0",

--- a/agent/package/application/package.rb
+++ b/agent/package/application/package.rb
@@ -1,5 +1,5 @@
 class MCollective::Application::Package<MCollective::Application
-  description "Generic Package Manager"
+  description "Install and uninstall software packages"
     usage <<-END_OF_USAGE
 mco package [OPTIONS] <ACTION> <PACKAGE>"
 

--- a/agent/puppetd/agent/puppetd.ddl
+++ b/agent/puppetd/agent/puppetd.ddl
@@ -1,12 +1,12 @@
-metadata    :name        => "SimpleRPC Agent for Puppet Agent",
-            :description => "Agent to manage the puppet agent daemon",
+metadata    :name        => "puppetd",
+            :description => "Run puppet agent, get its status, and enable/disable it",
             :author      => "R.I.Pienaar",
             :license     => "Apache License 2.0",
             :version     => "1.4",
             :url         => "https://github.com/puppetlabs/mcollective-plugins",
             :timeout     => 20
 
-action "last_run_summary", :description => "Retrieves a summary of the last puppet run" do
+action "last_run_summary", :description => "Get a summary of the last puppet run" do
     display :always
 
     output :time,
@@ -25,19 +25,19 @@ action "last_run_summary", :description => "Retrieves a summary of the last pupp
            :display_as => "Events"
 end
 
-action "enable", :description => "Enables puppet agent" do
+action "enable", :description => "Enable puppet agent" do
     output :output,
            :description => "String indicating status",
            :display_as => "Status"
 end
 
-action "disable", :description => "Disables puppet agent" do
+action "disable", :description => "Disable puppet agent" do
     output :output,
            :description => "String indicating status",
            :display_as => "Status"
 end
 
-action "runonce", :description => "Invokes a single puppet run" do
+action "runonce", :description => "Invoke a single puppet run" do
     #input :forcerun,
     #    :prompt      => "Force puppet run",
     #    :description => "Should the puppet run happen immediately?",
@@ -51,7 +51,7 @@ action "runonce", :description => "Invokes a single puppet run" do
            :display_as => "Output"
 end
 
-action "status", :description => "Returns puppet agent's status" do
+action "status", :description => "Get puppet agent's status" do
     display :always
 
     output :enabled,

--- a/agent/puppetd/agent/puppetd.rb
+++ b/agent/puppetd/agent/puppetd.rb
@@ -17,8 +17,8 @@ module MCollective
     #    puppetd.pidfile   - Where to find puppet agent's pid file; defaults to
     #                        /var/run/puppet/agent.pid
     class Puppetd<RPC::Agent
-      metadata    :name        => "SimpleRPC Puppet Agent",
-                  :description => "Agent to manage the puppet agent daemon",
+      metadata    :name        => "puppetd",
+                  :description => "Run puppet agent, get its status, and enable/disable it",
                   :author      => "R.I.Pienaar",
                   :license     => "Apache License 2.0",
                   :version     => "1.4",

--- a/agent/puppetd/application/puppetd.rb
+++ b/agent/puppetd/application/puppetd.rb
@@ -1,5 +1,5 @@
 class MCollective::Application::Puppetd<MCollective::Application
-  description "Remote Puppet daemon manager"
+  description "Run puppet agent, get its status, and enable/disable it"
     usage <<-END_OF_USAGE
 mco puppetd [OPTIONS] [FILTERS] <ACTION> [CONCURRENCY]
 

--- a/agent/puppetral/agent/puppetral.ddl
+++ b/agent/puppetral/agent/puppetral.ddl
@@ -1,5 +1,5 @@
-metadata    :name        => "Agent for Puppet RAL interaction",
-            :description => "Agent to inspect and act on the RAL",
+metadata    :name        => "puppetral",
+            :description => "View and edit resources with Puppet's resource abstraction layer",
             :author      => "R.I.Pienaar, Max Martin",
             :license     => "ASL2",
             :version     => "0.2",

--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -18,7 +18,7 @@ module MCollective
     # as long as you supply all of the attributes that the type requires.
     class Puppetral<RPC::Agent
       metadata  :name        => "puppetral",
-                :description => "Agent to inspect and act on the RAL",
+                :description => "View and edit resources with Puppet's resource abstraction layer",
                 :author      => "R.I.Pienaar <rip@devco.net>, Max Martin <max@puppetlabs.com>",
                 :license     => "ASL2",
                 :version     => "0.2",

--- a/agent/service/agent/puppet-service.rb
+++ b/agent/service/agent/puppet-service.rb
@@ -10,8 +10,8 @@ module MCollective
     #
     # As this agent is based on Simple RPC, it requires mcollective 0.4.7 or newer.
     class Service<RPC::Agent
-      metadata    :name        => "SimpleRPC Service Agent",
-                  :description => "Agent to manage services",
+      metadata    :name        => "service",
+                  :description => "Start and stop system services",
                   :author      => "R.I.Pienaar",
                   :license     => "ASL2",
                   :version     => "2.0",

--- a/agent/service/agent/service.ddl
+++ b/agent/service/agent/service.ddl
@@ -1,5 +1,5 @@
-metadata    :name        => "SimpleRPC Service Agent",
-            :description => "Agent to manage services",
+metadata    :name        => "service",
+            :description => "Start and stop system services",
             :author      => "R.I.Pienaar",
             :license     => "ASL2",
             :version     => "1.2",

--- a/agent/service/application/service.rb
+++ b/agent/service/application/service.rb
@@ -1,6 +1,6 @@
 module MCollective
   class Application::Service < Application
-    description "Manage remote services"
+    description "Start and stop system services"
 
     usage <<-END_OF_USAGE
 mco service [OPTIONS] [FILTERS] <SERVICE> <ACTION>


### PR DESCRIPTION
This commit edits the name and description fields of the puppetral, puppetd, service, and package agents/applications/ddls. Names, descriptions, and actions for these agents now match the following guidelines:
- Standardize on the imperative mood
- The name should be the common name of the agent
- When possible, descriptions should summarize the most important actions
  (instead of using unclear super-actions like "manage" or "control")
  - Use "and" instead of "or" when summarizing actions
