### PR TITLE
Maint: Fix "name" field for long help output

### DIFF
--- a/agent/package/agent/package.ddl
+++ b/agent/package/agent/package.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "package",
+metadata    :name        => "Package Agent",
             :description => "Install and uninstall software packages",
             :author      => "R.I.Pienaar",
             :license     => "ASL2",

--- a/agent/package/agent/puppet-package.rb
+++ b/agent/package/agent/puppet-package.rb
@@ -10,7 +10,7 @@ module MCollective
     #
     # As this agent is based on Simple RPC, it requires mcollective 0.4.7 or newer.
     class Package<RPC::Agent
-      metadata    :name        => "package",
+      metadata    :name        => "Package Agent",
                   :description => "Install and uninstall software packages",
                   :author      => "R.I.Pienaar",
                   :license     => "ASL2",

--- a/agent/puppetd/agent/puppetd.ddl
+++ b/agent/puppetd/agent/puppetd.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "puppetd",
+metadata    :name        => "Puppet Controller Agent",
             :description => "Run puppet agent, get its status, and enable/disable it",
             :author      => "R.I.Pienaar",
             :license     => "Apache License 2.0",

--- a/agent/puppetd/agent/puppetd.rb
+++ b/agent/puppetd/agent/puppetd.rb
@@ -17,7 +17,7 @@ module MCollective
     #    puppetd.pidfile   - Where to find puppet agent's pid file; defaults to
     #                        /var/run/puppet/agent.pid
     class Puppetd<RPC::Agent
-      metadata    :name        => "puppetd",
+      metadata    :name        => "Puppet Controller Agent",
                   :description => "Run puppet agent, get its status, and enable/disable it",
                   :author      => "R.I.Pienaar",
                   :license     => "Apache License 2.0",

--- a/agent/puppetral/agent/puppetral.ddl
+++ b/agent/puppetral/agent/puppetral.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "puppetral",
+metadata    :name        => "Resource Abstraction Layer Agent",
             :description => "View and edit resources with Puppet's resource abstraction layer",
             :author      => "R.I.Pienaar, Max Martin",
             :license     => "ASL2",

--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -17,7 +17,7 @@ module MCollective
     # You can use puppetral to declare instances of any sensible Puppet type,
     # as long as you supply all of the attributes that the type requires.
     class Puppetral<RPC::Agent
-      metadata  :name        => "puppetral",
+      metadata  :name        => "Resource Abstraction Layer Agent",
                 :description => "View and edit resources with Puppet's resource abstraction layer",
                 :author      => "R.I.Pienaar <rip@devco.net>, Max Martin <max@puppetlabs.com>",
                 :license     => "ASL2",

--- a/agent/service/agent/puppet-service.rb
+++ b/agent/service/agent/puppet-service.rb
@@ -10,7 +10,7 @@ module MCollective
     #
     # As this agent is based on Simple RPC, it requires mcollective 0.4.7 or newer.
     class Service<RPC::Agent
-      metadata    :name        => "service",
+      metadata    :name        => "Service Agent",
                   :description => "Start and stop system services",
                   :author      => "R.I.Pienaar",
                   :license     => "ASL2",

--- a/agent/service/agent/service.ddl
+++ b/agent/service/agent/service.ddl
@@ -1,4 +1,4 @@
-metadata    :name        => "service",
+metadata    :name        => "Service Agent",
             :description => "Start and stop system services",
             :author      => "R.I.Pienaar",
             :license     => "ASL2",


### PR DESCRIPTION
MCollective's long help output uses the "name" field as the main header for an
agent's help page, which makes the short name (as used when invoking)
impractical for use in that field. This commit changes the name fields of the
package, service, puppetd, and puppetral agents/ddl files to short
descriptions suitable for long help output.
