### PR TITLE
(#10221) Update puppetd plugin to take advantage of new agent statuses

### DIFF
--- a/agent/puppetd/agent/puppetd.ddl
+++ b/agent/puppetd/agent/puppetd.ddl
@@ -2,7 +2,7 @@ metadata    :name        => "Puppet Controller Agent",
             :description => "Run puppet agent, get its status, and enable/disable it",
             :author      => "R.I.Pienaar",
             :license     => "Apache License 2.0",
-            :version     => "1.4",
+            :version     => "1.5",
             :url         => "https://github.com/puppetlabs/mcollective-plugins",
             :timeout     => 20
 
@@ -54,6 +54,10 @@ end
 action "status", :description => "Get puppet agent's status" do
     display :always
 
+    output :status,
+           :description => "The status of the puppet agent: disabled, running, idling or stopped",
+           :display_as => "Status"
+
     output :enabled,
            :description => "Whether puppet agent is enabled",
            :display_as => "Enabled"
@@ -61,6 +65,14 @@ action "status", :description => "Get puppet agent's status" do
     output :running,
            :description => "Whether puppet agent is running",
            :display_as => "Running"
+
+    output :idling,
+           :description => "Whether puppet agent is idling",
+           :display_as => "Idling"
+
+    output :stopped,
+           :description => "Whether puppet agent is stopped",
+           :display_as => "Stopped"
 
     output :lastrun,
            :description => "When puppet agent last ran",

--- a/agent/puppetd/agent/puppetd.rb
+++ b/agent/puppetd/agent/puppetd.rb
@@ -21,7 +21,7 @@ module MCollective
                   :description => "Run puppet agent, get its status, and enable/disable it",
                   :author      => "R.I.Pienaar",
                   :license     => "Apache License 2.0",
-                  :version     => "1.4",
+                  :version     => "1.5",
                   :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AgentPuppetd",
                   :timeout     => 30
 
@@ -51,7 +51,7 @@ module MCollective
       end
 
       action "status" do
-        status
+        set_status
       end
 
       private
@@ -65,48 +65,38 @@ module MCollective
         end
       end
 
-      def status
-        reply[:enabled] = 0
-        reply[:running] = 0
+      def set_status
+        reply[:status]  = puppet_daemon_status
+        reply[:running] = reply[:status] == 'running'  ? 1 : 0
+        reply[:enabled] = reply[:status] == 'disabled' ? 0 : 1
+        reply[:idling]  = reply[:status] == 'idling'   ? 1 : 0
+        reply[:stopped] = reply[:status] == 'stopped'  ? 1 : 0
         reply[:lastrun] = 0
-
-        if File.exists?(@lockfile)
-          if File::Stat.new(@lockfile).zero?
-            reply[:output] = "Disabled, not running"
-          else
-            reply[:output] = "Enabled, running"
-            reply[:enabled] = 1
-            reply[:running] = 1
-          end
-        else
-          reply[:output] = "Enabled, not running"
-          reply[:enabled] = 1
-        end
-
         reply[:lastrun] = File.stat(@statefile).mtime.to_i if File.exists?(@statefile)
-        reply[:output] += ", last run #{Time.now.to_i - reply[:lastrun]} seconds ago"
+        reply[:output]  = "Currently #{reply[:status]}; last completed run #{Time.now.to_i - reply[:lastrun]} seconds ago"
       end
 
-
-      # We would like to merge this method with the above status method some day
       def puppet_daemon_status
         locked = File.exists?(@lockfile)
+        disabled = locked && File::Stat.new(@lockfile).zero?
         has_pid = File.exists?(@pidfile)
-        return :running  if   locked &&   has_pid
-        return :disabled if   locked && ! has_pid
-        return :idling   if ! locked &&   has_pid
-        return :stopped  if ! locked && ! has_pid
+
+        return 'disabled' if disabled
+        return 'running'  if   locked && has_pid
+        return 'idling'   if ! locked && has_pid
+        return 'stopped'  if ! has_pid
       end
 
       def runonce
-        case (state = puppet_daemon_status)
-        when :disabled then     # can't run
-          reply.fail "Lock file exists, but no PID file; puppet agent looks disabled."
+        set_status
+        case (reply[:status])
+        when 'disabled' then     # can't run
+          reply.fail "Empty Lock file exists; puppet agent is disabled."
 
-        when :running then      # can't run two simultaniously
-          reply.fail "Lock file and PID file exist; puppet agent appears to be running."
+        when 'running' then      # can't run two simultaniously
+          reply.fail "Lock file and PID file exist; puppet agent is running."
 
-        when :idling then       # signal daemon
+        when 'idling' then       # signal daemon
           pid = File.read(@pidfile)
           if pid !~ /^\d+$/
             reply.fail "PID file does not contain a PID; got #{pid.inspect}"
@@ -119,7 +109,7 @@ module MCollective
               # theoretically signal arbitrary processes with this...
               begin
                 ::Process.kill("USR1", Integer(pid))
-                reply[:output] = "Signalled daemonized puppet agent to run (process #{Integer(pid)})"
+                reply[:output] = "Signalled daemonized puppet agent to run (process #{Integer(pid)}); " + (reply[:output] || '')
               rescue Exception => e
                 reply.fail "Failed to signal the puppet agent daemon (process #{pid}): #{e}"
               end
@@ -129,11 +119,11 @@ module MCollective
             end
           end
 
-        when :stopped then      # just run
+        when 'stopped' then      # just run
           runonce_background
 
         else
-          reply.fail "Unknown puppet agent state: #{state}"
+          reply.fail "Unknown puppet agent status: #{reply[:status]}"
         end
       end
 
@@ -148,7 +138,9 @@ module MCollective
 
         cmd = cmd.join(" ")
 
+        output = reply[:output] || ''
         run(cmd, :stdout => :output, :chomp => true)
+        reply[:output] = "Called #{cmd}, " + output + (reply[:output] || '')
       end
 
       def enable
@@ -162,7 +154,7 @@ module MCollective
             reply[:output] = "Currently running; can't remove lock"
           end
         else
-          reply.fail "Already unlocked"
+          reply.fail "Already enabled"
         end
       end
 
@@ -173,8 +165,7 @@ module MCollective
           stat.zero? ? reply.fail("Already disabled") : reply.fail("Currently running; can't remove lock")
         else
           begin
-            File.open(@lockfile, "w") do |file|
-            end
+            File.open(@lockfile, "w") { |file| }
 
             reply[:output] = "Lock created"
           rescue Exception => e

--- a/agent/puppetd/spec/puppetd_agent_spec.rb
+++ b/agent/puppetd/spec/puppetd_agent_spec.rb
@@ -38,7 +38,7 @@ describe "puppetd agent" do
       File.expects(:exists?).returns(false)
       result = @agent.call(:enable)
       result.should be_aborted_error
-      result[:statusmsg].should == "Already unlocked"
+      result[:statusmsg].should == "Already enabled"
     end
 
     it "should attempt to remove zero byte lockfiles" do
@@ -112,25 +112,26 @@ describe "puppetd agent" do
   end
 
   describe "#runonce" do
+    before do
+      @agent.instance_variable_set("@statefile", "spec_test_state_file")
+    end
+
     it "with puppet agent disabled" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(true)
-      File.expects(:exists?).with("spec_test_pid_file").returns(false)
+      @agent.expects(:puppet_daemon_status).returns('disabled')
       result = @agent.call(:runonce)
       result.should be_aborted_error
-      result[:statusmsg].should == "Lock file exists, but no PID file; puppet agent looks disabled."
+      result[:statusmsg].should == "Empty Lock file exists; puppet agent is disabled."
     end
 
     it "with puppet agent actively running" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(true)
-      File.expects(:exists?).with("spec_test_pid_file").returns(true)
+      @agent.expects(:puppet_daemon_status).returns('running')
       result = @agent.call(:runonce)
-      result[:statusmsg].should == "Lock file and PID file exist; puppet agent appears to be running."
+      result[:statusmsg].should == "Lock file and PID file exist; puppet agent is running."
       result.should be_aborted_error
     end
 
     it "with puppet agent stopped" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(false)
-      File.expects(:exists?).with("spec_test_pid_file").returns(false)
+      @agent.expects(:puppet_daemon_status).returns('stopped')
       @agent.instance_variable_set("@puppetd", "spec_test_puppetd")
       @agent.expects(:run).with("spec_test_puppetd --onetime", :stdout => :output, :chomp => true)
       result = @agent.call(:runonce)
@@ -139,20 +140,18 @@ describe "puppetd agent" do
     end
 
     it "with puppet agent idling as a daemon" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(false)
-      File.expects(:exists?).with("spec_test_pid_file").returns(true)
+      @agent.expects(:puppet_daemon_status).returns('idling')
       File.expects(:read).with("spec_test_pid_file").returns("99999999\n")
       ::Process.expects(:kill).with(0, 99999999).returns(1)
       ::Process.expects(:kill).with("USR1", 99999999).once
       result = @agent.call(:runonce)
       result[:statusmsg].should == "OK"
-      result[:data][:output].should == "Signalled daemonized puppet agent to run (process 99999999)"
+      result[:data][:output].should =~ /Signalled daemonized puppet agent to run \(process 99999999\); Currently idling; last completed run/
       result.should be_successful
     end
 
-    it "with puppet agent stopped but PID file present" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(false)
-      File.expects(:exists?).with("spec_test_pid_file").returns(true)
+    it "with puppet agent stale pid file" do
+      @agent.expects(:puppet_daemon_status).returns('idling')
       File.expects(:read).with("spec_test_pid_file").returns("99999999\n")
       ::Process.expects(:kill).with(0, 99999999).raises(Errno::ESRCH)
       ::Process.expects(:kill).with("USR1", 99999999).never
@@ -164,8 +163,7 @@ describe "puppetd agent" do
     end
 
     it "with PID file containing rubbish" do
-      File.expects(:exists?).with("spec_test_lock_file").returns(false)
-      File.expects(:exists?).with("spec_test_pid_file").returns(true)
+      @agent.expects(:puppet_daemon_status).returns('idling')
       File.expects(:read).with("spec_test_pid_file").returns("fred\nwilma\nbarney\n")
       result = @agent.call(:runonce)
       result[:statusmsg].should == "PID file does not contain a PID; got \"fred\\nwilma\\nbarney\\n\""
@@ -199,48 +197,88 @@ describe "puppetd agent" do
       stat = mock
       stat.stubs(:zero?).returns(true)
       @agent.instance_variable_set("@statefile", "spec_test_state_file")
+      @agent.instance_variable_set("@pidfile", "spec_test_pid_file")
 
       File.expects(:exists?).with("spec_test_lock_file").returns(true)
       File::Stat.expects(:new).with("spec_test_lock_file").returns(stat)
       File.expects(:exists?).with("spec_test_state_file").returns(false)
+      File.expects(:exists?).with("spec_test_pid_file").returns(false)
 
       result = @agent.call(:status)
       result.should be_successful
-      result.should have_data_items({:running => 0,
-                                      :enabled => 0,
-                                      :lastrun => 0,
-                                      :output => /Disabled, not running, last run/})
-
+      result.should have_data_items({
+        :status  => 'disabled',
+        :running => 0,
+        :enabled => 0,
+        :idling  => 0,
+        :stopped => 0,
+        :lastrun => 0,
+        :output  => /Currently disabled; last completed run \d+ seconds ago/
+      })
     end
 
-    it "is enabled and running when the lockfile exists and its size is not 0" do
+    it "is enabled and running when the pidfile exists and the lockfile exists and its size is not 0" do
       stat = mock
       stat.stubs(:zero?).returns(false)
       @agent.instance_variable_set("@statefile", "spec_test_state_file")
+      @agent.instance_variable_set("@pidfile", "spec_test_pid_file")
 
       File.expects(:exists?).with("spec_test_lock_file").returns(true)
       File::Stat.expects(:new).with("spec_test_lock_file").returns(stat)
       File.expects(:exists?).with("spec_test_state_file").returns(false)
+      File.expects(:exists?).with("spec_test_pid_file").returns(true)
 
       result = @agent.call(:status)
       result.should be_successful
-      result.should have_data_items({:running => 1,
-                                      :enabled => 1,
-                                      :lastrun => 0,
-                                      :output => /Enabled, running, last run/})
+      result.should have_data_items({
+        :status  => 'running',
+        :running => 1,
+        :enabled => 1,
+        :idling  => 0,
+        :stopped => 0,
+        :lastrun => 0,
+        :output  => /Currently running; last completed run \d+ seconds ago/
+      })
     end
 
-    it "is enabled and not running if the lockfile does not exist" do
+    it "is enabled and idling if the pidfile exists but the lockfile does not exist" do
       File.expects(:exists?).with("spec_test_lock_file").returns(false)
       File.expects(:exists?).with("spec_test_state_file").returns(false)
+      File.expects(:exists?).with("spec_test_pid_file").returns(true)
+
       @agent.instance_variable_set("@statefile", "spec_test_state_file")
 
       result = @agent.call(:status)
       result.should be_successful
-      result.should have_data_items({:running => 0,
-                                      :enabled => 1,
-                                      :lastrun => 0,
-                                      :output => /Enabled, not running, last run/})
+      result.should have_data_items({
+        :status  => 'idling',
+        :running => 0,
+        :enabled => 1,
+        :idling  => 1,
+        :stopped => 0,
+        :lastrun => 0,
+        :output  => /Currently idling; last completed run \d+ seconds ago/
+      })
+    end
+
+    it "is enabled and stopped if the pidfile does not exist and the lockfile does not exist" do
+      File.expects(:exists?).with("spec_test_lock_file").returns(false)
+      File.expects(:exists?).with("spec_test_state_file").returns(false)
+      File.expects(:exists?).with("spec_test_pid_file").returns(false)
+
+      @agent.instance_variable_set("@statefile", "spec_test_state_file")
+
+      result = @agent.call(:status)
+      result.should be_successful
+      result.should have_data_items({
+        :status  => 'stopped',
+        :running => 0,
+        :enabled => 1,
+        :idling  => 0,
+        :stopped => 1,
+        :lastrun => 0,
+        :output  => /Currently stopped; last completed run \d+ seconds ago/
+      })
     end
   end
 end

--- a/agent/puppetd/spec/puppetd_application_spec.rb
+++ b/agent/puppetd/spec/puppetd_application_spec.rb
@@ -120,8 +120,19 @@ module Mcollective
 
         @app.stubs(:configuration).returns({:command => "status"})
         @app.expects(:rpcclient).with("puppetd", :options => nil).returns(rpcclient_mock)
-        rpcclient_mock.expects(:send).returns([{:sender => "node1", :statuscode => 0, :data => {:output => "success"}},{:sender => "node2", :statuscode => 1, :statusmsg => "failure"}])
-        @app.expects(:puts).with("node1                                    success")
+        rpcclient_mock.expects(:send).returns([
+          {
+            :sender     => "node1",
+            :statuscode => 0,
+            :data       => {:output => "Currently idling; success"}
+          },
+          {
+            :sender     => "node2",
+            :statuscode => 1,
+            :statusmsg  => "failure"
+          }
+        ])
+        @app.expects(:puts).with("node1                                    Currently idling; success")
         @app.expects(:puts).with("node2                                    failure")
         @util.config.stubs(:color)
         rpcclient_mock.expects(:disconnect)
@@ -160,10 +171,17 @@ module Mcollective
         @app.stubs(:configuration).returns({:command => "count"})
         @app.expects(:rpcclient).with("puppetd", :options => nil).returns(rpcclient_mock)
         rpcclient_mock.expects(:progress=).with(false)
-        rpcclient_mock.expects(:status).yields(:body => {:data => {:running => "1", :enabled => "1"}})
-        @app.expects(:puts).with("Nodes currently doing puppet runs: 1")
+        rpcclient_mock.expects(:status).yields(:body => {:data => {
+          :running => "1",
+          :enabled => "1",
+          :stopped => "0",
+          :idling  => "0"
+        }})
         @app.expects(:puts).with("          Nodes currently enabled: 1")
         @app.expects(:puts).with("         Nodes currently disabled: 0")
+        @app.expects(:puts).with("Nodes currently doing puppet runs: 1")
+        @app.expects(:puts).with("          Nodes currently stopped: 0")
+        @app.expects(:puts).with("           Nodes currently idling: 0")
         rpcclient_mock.expects(:disconnect)
 
         @app.main


### PR DESCRIPTION
Ticket #9923 allowed the puppetd plugin to trigger agent runs even when
the agent was already daemonized, but it introduced some new state
information about the puppet agent, :idling and :stopped, that wasn't
consolidated very well with the current understanding of puppet state by
other areas on the plugin.

This commit consolidates that state information to reply[:status], and
adds the reply[:idling] and reply[:stopped], like the reply[:running]
and reply[:enabled], for backward compatibility and easy command line
manipulation of the status information.

The agent, application and ddl were all updated to take advantage of
this new state information.

See https://github.com/puppetlabs/mcollective-plugins/pull/29 for previous discussion on this code.  I'm making this new pull request since it's been rebased and should merge with a single click.
