### PR TITLE
Add yum_clean_expirecache method to package agent.

### DIFF
--- a/agent/package/agent/package.ddl
+++ b/agent/package/agent/package.ddl
@@ -46,14 +46,16 @@ action "status", :description => "Get the status of a package" do
            :display_as  => "Properties"
 end
 
-action "yum_clean", :description => "Clean the YUM cache" do
-    output :output,
-           :description => "Output from YUM",
-           :display_as  => "Output"
+["yum_clean", "yum_clean_expirecache"].each do |act|
+    action act, :description => "Clean the YUM cache (#{act[4..-1].sub('_', ' ')})" do
+        output :output,
+               :description => "Output from YUM",
+               :display_as  => "Output"
 
-    output :exitcode,
-           :description => "The exitcode from the yum command",
-           :display_as => "Exit Code"
+        output :exitcode,
+               :description => "The exitcode from the yum command",
+               :display_as => "Exit Code"
+    end
 end
 
 action "apt_update", :description => "Update the apt cache" do

--- a/agent/package/agent/puppet-package.rb
+++ b/agent/package/agent/puppet-package.rb
@@ -29,7 +29,14 @@ module MCollective
         reply.fail! "Cannot find yum at /usr/bin/yum" unless File.exist?("/usr/bin/yum")
         reply[:exitcode] = run("/usr/bin/yum clean all", :stdout => :output, :chomp => true)
 
-        reply.fail! "Yum clean failed, exit code was #{reply[:exitcode]}" unless reply[:exitcode] == 0
+        reply.fail! "Yum clean all failed, exit code was #{reply[:exitcode]}" unless reply[:exitcode] == 0
+      end
+
+      action "yum_clean_expirecache" do
+        reply.fail! "Cannot find yum at /usr/bin/yum" unless File.exist?("/usr/bin/yum")
+        reply[:exitcode] = run("/usr/bin/yum clean expire-cache", :stdout => :output, :chomp => true)
+
+        reply.fail! "Yum clean expire-cache failed, exit code was #{reply[:exitcode]}" unless reply[:exitcode] == 0
       end
 
       action "apt_update" do


### PR DESCRIPTION
Hi PuppetLabs,

I added a "yum_clean_expirecache" method to the package-agent. "yum clean expire-cache" is much more light weight than "yum clean all", which is currently implemented.
This speeds up situations, where you just uploaded a package to the yum-repository and have to client invalidate the cache.

I would be happy to see this tiny change in your modules.

Thanks,
Jens
