### PR TITLE
Don't die in an unclear way if you forget the registration is Meta config

### DIFF
--- a/agent/registration-mongodb/registration.rb
+++ b/agent/registration-mongodb/registration.rb
@@ -55,6 +55,11 @@ module MCollective
       def handlemsg(msg, connection)
         req = msg[:body]
 
+        if (req.kind_of?(Array))
+          Log.instance.warn("Got no facts - did you forget to add 'registration = Meta' to your server.cfg?");
+          return nill
+        end
+
         req[:fqdn] = req[:facts]["fqdn"]
         req[:lastseen] = Time.now.to_i
 


### PR DESCRIPTION
Simple fix to log a better error message rather than failing.
