### PR TITLE
(#13429) refactor puppetral agent for telly compatibility

### DIFF
--- a/agent/puppetca/agent/puppetca.rb
+++ b/agent/puppetca/agent/puppetca.rb
@@ -23,7 +23,7 @@ module MCollective
         signed = paths_for_cert(certname)[:signed]
         csr = paths_for_cert(certname)[:request]
 
-        msg = []
+        msg = new_msg_array
 
         if has_cert?(certname)
           File.unlink(signed)
@@ -105,6 +105,13 @@ module MCollective
         {:signed => "#{@cadir}/signed/#{certname}.pem",
           :request => "#{@cadir}/requests/#{certname}.pem"}
       end
+
+      # This is only here to simplify testing, so that we can simulate
+      #  various lengths of the msg queue
+      def new_msg_array()
+        []
+      end
+      private :new_msg_array
     end
   end
 end

--- a/agent/puppetca/spec/puppetca_agent_spec.rb
+++ b/agent/puppetca/spec/puppetca_agent_spec.rb
@@ -48,10 +48,13 @@ describe "puppetca agent" do
     end
 
     it "should return the message if there are no certs but msg.size is not 0" do
+      @msg_array = []
+
       @agent.expects(:paths_for_cert).with("certname").twice.returns({:signed => "signed", :request => "request"})
       @agent.expects(:has_cert?).with("certname").returns(false)
       @agent.expects(:cert_waiting?).with("certname").returns(false)
-      Array.any_instance.expects(:size).returns(1)
+      @agent.expects(:new_msg_array).returns(@msg_array)
+      @msg_array.expects(:size).returns(1)
       result = @agent.call(:clean, :certname => "certname")
       result.should be_successful
       result.should have_data_items(:msg => "")

--- a/agent/puppetral/agent/puppetral.rb
+++ b/agent/puppetral/agent/puppetral.rb
@@ -1,4 +1,5 @@
 require 'puppet'
+require 'puppet/face/resource'
 
 module MCollective
   module Agent
@@ -17,6 +18,11 @@ module MCollective
     # You can use puppetral to declare instances of any sensible Puppet type,
     # as long as you supply all of the attributes that the type requires.
     class Puppetral<RPC::Agent
+      def initialize
+        super
+        Puppet.initialize_settings
+      end
+
       metadata  :name        => "Resource Abstraction Layer Agent",
                 :description => "View and edit resources with Puppet's resource abstraction layer",
                 :author      => "R.I.Pienaar <rip@devco.net>, Max Martin <max@puppetlabs.com>",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'mcollective/test'
 require 'rspec/mocks'
 require 'mocha'
 require 'tempfile'
+require 'puppet_spec_helper'
 
 RSpec.configure do |config|
   config.mock_with :mocha


### PR DESCRIPTION
R.I. (and anyone else interested): I'm not sure if you'll want to actually merge this or not, but it demonstrates how to make the puppetral agent code and specs compatible with Telly.  It will break backwards compatibility with previous versions of puppet so that will obviously play a role in the decision of whether to merge as-is and establish a version-compatibility matrix, or whether to modify this commit with some backwards-compatibility hacks, or...

---

This commit includes:
- Small change to puppetral agent to ensure puppet settings are
  initialized properly prior to use; this is necessary for
  compatibility with Telly
- Add "puppet_spec_helper" (from puppetlabs_spec_helper project)
  to local spec_helper
