### PR TITLE
Typo in check-mc-nrpe

### DIFF
--- a/agent/nrpe/sbin/check-mc-nrpe
+++ b/agent/nrpe/sbin/check-mc-nrpe
@@ -62,7 +62,7 @@ puts("#{command}: OK: %d WARNING: %d CRITICAL: %d UNKNOWN: %d|total=%d ok=%d war
   end
 end
 
-nrpe.disconnet
+nrpe.disconnect
 
 # if there's any critical checks, exit critical
 # else just take the highest.  UNKNOWN is 3 while


### PR DESCRIPTION
This typo was causing my checks to fail with DDL validate failures.
