### PR TITLE
Fixed #15111 - Fixed typo in yum checkupdates in package agent

### DIFF
--- a/agent/package/agent/package.ddl
+++ b/agent/package/agent/package.ddl
@@ -2,7 +2,7 @@ metadata    :name        => "Package Agent",
             :description => "Install and uninstall software packages",
             :author      => "R.I.Pienaar",
             :license     => "ASL2",
-            :version     => "3.0",
+            :version     => "3.1",
             :url         => "https://github.com/puppetlabs/mcollective-plugins",
             :timeout     => 180
 
@@ -128,7 +128,7 @@ action "yum_checkupdates", :description => "Check for YUM updates" do
            :description => "Output from YUM",
            :display_as  => "Output"
 
-    output :oudated_packages,
+    output :outdated_packages,
            :description => "Outdated packages",
            :display_as  => "Outdated Packages"
 

--- a/agent/package/agent/puppet-package.rb
+++ b/agent/package/agent/puppet-package.rb
@@ -7,7 +7,7 @@ module MCollective
                :description => "Install and uninstall software packages",
                :author      => "R.I.Pienaar",
                :license     => "ASL2",
-               :version     => "3.0",
+               :version     => "3.1",
                :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
                :timeout     => 180
 


### PR DESCRIPTION
The DDL has an output value of oudated_packages. The agent expects to populate outdated_packages. This causes Live Management to barf on yum checkupdates.
