### PR TITLE
17203 - Dsh plugin uses discovery instead of rpcutil

### DIFF
--- a/agent/dsh/application/dsh.rb
+++ b/agent/dsh/application/dsh.rb
@@ -5,7 +5,7 @@ class MCollective::Application::Dsh<MCollective::Application
   usage "mco dsh [filters] -- (dsh commands)"
 
   def main
-    mc = rpcclient("discovery")
+    mc = rpcclient("rpcutil")
 
     raise "No hosts discovered" if mc.discover.empty?
 


### PR DESCRIPTION
Dsh application was not working because it was looking for the discovery
agent which does not have a DDL.  After applying this fix, the application
now uses rpcutil and no longer fails.
