### PR TITLE
Source and install_option parameter for package agent

### DIFF
--- a/agent/package/agent/package.ddl
+++ b/agent/package/agent/package.ddl
@@ -16,6 +16,22 @@ metadata    :name        => "package",
               :optional    => false,
               :maxlength   => 90
 
+        input :source,
+              :prompt      => "Package Source",
+              :description => "Package source to #{act}",
+              :type        => :string,
+              :validation  => '.',
+              :optional    => true,
+              :maxlength   => 90
+
+        input :install_options,
+              :prompt      => "Package Install Option",
+              :description => "Package Install Options",
+              :type        => :string,
+              :validation  => '.',
+              :optional    => true,
+              :maxlength   => 90
+
         output :output,
                :description => "Output from the package manager",
                :display_as  => "Output"

--- a/agent/package/agent/package.rb
+++ b/agent/package/agent/package.rb
@@ -16,7 +16,7 @@ module MCollective
         action act do
           validate :package, :shellsafe
 
-          properties, output = do_pkg_action(request[:package], act.to_sym)
+          properties, output = do_pkg_action(request, act.to_sym)
 
           reply[:output] = output
 
@@ -94,9 +94,19 @@ module MCollective
       end
 
       private
-      def do_pkg_action(package, action)
+      def do_pkg_action(request, action)
         begin
-          pkg = ::Puppet::Type.type(:package).new(:name => package).provider
+          if request.include?(:source)
+            if request.include?(:install_options)
+              pkg = ::Puppet::Type.type(:package).new(:name => request[:package],
+                                                      :source => request[:source],
+                                                      :install_options => eval(request[:install_options])).provider
+            else
+              pkg = ::Puppet::Type.type(:package).new(:name => request[:package], :source => request[:source]).provider
+            end
+          else
+            pkg = ::Puppet::Type.type(:package).new(:name => request[:package]).provider
+          end
 
           output = ""
           properties = ""


### PR DESCRIPTION
This patch will add support for "source" and "install_options" parameter to package agent. With those options you will be able to install windows packages.

mco example:
% mco rpc package install package="Some Software" source="c:\path\to\some-software-1.0.msi" install_options="{ 'TARGET' => 'C:\' }" -F kernel=windows 
