### PR TITLE
Fix method signature, doesn't match security/base.rb

### DIFF
--- a/security/none/none.rb
+++ b/security/none/none.rb
@@ -16,13 +16,13 @@ module MCollective
       end
 
       # Encodes a reply
-      def encodereply(sender, target, msg, requestid, requestcallerid=nil)
-        YAML.dump(create_reply(requestid, sender, target, msg))
+      def encodereply(sender, msg, requestid, requestcallerid=nil)
+        YAML.dump(create_reply(requestid, sender, msg))
       end
 
       # Encodes a request msg
-      def encoderequest(sender, target, msg, requestid, filter, target_agent, target_collective)
-        request = create_request(requestid, target, filter, msg, @initiated_by, target_agent, target_collective)
+      def encoderequest(sender, msg, requestid, filter, target_agent, target_collective, ttl=60)
+        request = create_request(requestid, filter, msg, @initiated_by, target_agent, target_collective, ttl)
 
         YAML.dump(request)
       end


### PR DESCRIPTION
Copied from RI's https://github.com/ripienaar/mcollective-vagrant

On broken server responding to mco ping:

```
E, [2014-01-09T21:52:37.872446 #25854] ERROR -- : agents.rb:138:in `rescue in block in dispatch' Execution of discovery failed: wrong number of arguments (4 for 3)
E, [2014-01-09T21:52:37.872777 #25854] ERROR -- : agents.rb:139:in `rescue in block in dispatch' /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/security/base.rb:167:in `create_reply'
        /Users/simon/src/marionette-collective/plugins/mcollective/security/none.rb:20:in `encodereply'
        /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/message.rb:140:in `encode!'
        /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/runner.rb:128:in `reply'
        /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/runner.rb:83:in `block in agentmsg'
        /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/agents.rb:132:in `block (2 levels) in dispatch'
```

From broken client:

```
$ mco ping
W, [2014-01-09T21:51:41.361582 #25854]  WARN -- : runner.rb:71:in `rescue in block in run' Failed to handle message: undefined method `keys' for "ping":String - NoMethodError

W, [2014-01-09T21:51:41.361805 #25854]  WARN -- : runner.rb:72:in `rescue in block in run' /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/security/base.rb:61:in `validate_filter?'
    /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/message.rb:211:in `validate'
    /Users/simon/.rvm/gems/ruby-2.1.0@vlad/gems/mcollective-2.2.3/lib/mcollective/runner.rb:120:in `receive'
```
