### PR TITLE
Adding support for a remote database

### DIFF
--- a/agent/registration-mongodb/agent/registration.rb
+++ b/agent/registration-mongodb/agent/registration.rb
@@ -92,7 +92,11 @@ module MCollective
         before = Time.now.to_f
         begin
           doc = @coll.find_and_modify(:query => by_fqdn, :update => {'$set' => req}, :new => true)
-          doc_id = doc['_id']
+          if doc
+            doc_id = doc['_id']
+          else
+            doc_id = @coll.insert(req, {:safe => true})
+          end
         rescue Mongo::OperationFailure
           doc_id = @coll.insert(req, {:safe => true})
         ensure

--- a/agent/registration-mongodb/agent/registration.rb
+++ b/agent/registration-mongodb/agent/registration.rb
@@ -44,13 +44,19 @@ module MCollective
         @config = Config.instance
 
         @mongohost = @config.pluginconf["registration.mongohost"] || "localhost"
+        @mongoport = @config.pluginconf["registration.mongoport"] || "27017"
         @mongodb = @config.pluginconf["registration.mongodb"] || "puppet"
+        @mongouser = @config.pluginconf["registration.mongouser"]
+        @mongopass = @config.pluginconf["registration.mongopass"]
         @collection = @config.pluginconf["registration.collection"] || "nodes"
         @yaml_dir = @config.pluginconf["registration.extra_yaml_dir"] || false
 
-        Log.instance.debug("Connecting to mongodb @ #{@mongohost} db #{@mongodb} collection #{@collection}")
+        Log.instance.debug("Connecting to mongodb @ #{@mongohost}:#{@mongoport} db #{@mongodb} collection #{@collection}")
 
-        @dbh = Mongo::Connection.new(@mongohost).db(@mongodb)
+        @dbh = Mongo::Connection.new(@mongohost,@mongoport).db(@mongodb)
+        unless @mongouser.empty?
+          @auth = @dbh.authenticate(@mongouser, @mongopass)
+        end
         @coll = @dbh.collection(@collection)
 
         @coll.create_index("fqdn", {:unique => true, :dropDups => true})

--- a/agent/registration-mongodb/discovery/mongo.rb
+++ b/agent/registration-mongodb/discovery/mongo.rb
@@ -8,11 +8,17 @@ module MCollective
           config = Config.instance
 
           mongohost = config.pluginconf["registration.mongohost"] || "localhost"
+          mongoport = config.pluginconf["registration.mongoport"] || "27017"
           mongodb = config.pluginconf["registration.mongodb"] || "puppet"
+          mongouser = config.pluginconf["registration.mongouser"]
+          mongopass = config.pluginconf["registration.mongopass"]
           collection = config.pluginconf["registration.collection"] || "nodes"
           newerthan = Time.now.to_i - Integer(config.pluginconf["registration.criticalage"] || 3600)
 
-          dbh = ::Mongo::Connection.new(mongohost).db(mongodb)
+          dbh = ::Mongo::Connection.new(mongohost,mongoport).db(mongodb)
+          unless mongouser.empty?
+            auth = dbh.authenticate(mongouser, mongopass)
+          end
           coll = dbh.collection(collection)
 
           found = []


### PR DESCRIPTION
Submission for supporting node registration to a remote database.

server.cfg properties are straightforward:

plugin.registration.mongohost = host.mongodb.com
plugin.registration.mongoport = 27017
plugin.registration.mongodb = puppet
plugin.registration.mongouser = mcollective-client
plugin.registration.mongopass = password
plugin.registration.collection = nodes
plugin.registration.criticalage = 3600
